### PR TITLE
Allow overriding JTAG interface device when running docker image

### DIFF
--- a/docker/raspi3-openocd/Dockerfile
+++ b/docker/raspi3-openocd/Dockerfile
@@ -57,4 +57,5 @@ RUN set -ex;                                                            \
 
 COPY rpi3.cfg /openocd/
 
-ENTRYPOINT ["openocd", "-f", "/openocd/tcl/interface/ftdi/olimex-arm-usb-tiny-h.cfg", "-f", "/openocd/rpi3.cfg"]
+ENTRYPOINT ["openocd"]
+CMD ["-f", "/openocd/tcl/interface/ftdi/olimex-arm-usb-tiny-h.cfg", "-f", "/openocd/rpi3.cfg"]


### PR DESCRIPTION
This will require any non-standard use of this container to also
specify the rpi3.cfg path when invoking.

For example:
`docker run ... -f /openocd/tcl/interface/jlink.cfg -f /openocd/rpi3.cfg`
to work with JLink interface.

Ref #18 