### PR TITLE
Update README.md

### DIFF
--- a/0B_hw_debug_JTAG/Makefile
+++ b/0B_hw_debug_JTAG/Makefile
@@ -67,7 +67,7 @@ qemu: all
 
 raspboot: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(DOCKER_ARG_TTY) \
-	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) kernel8.img
+	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) kernel8.img
 
 clippy:
 	cargo xclippy --target=$(TARGET)

--- a/0B_hw_debug_JTAG/Makefile
+++ b/0B_hw_debug_JTAG/Makefile
@@ -33,9 +33,11 @@ CARGO_OUTPUT = target/$(TARGET)/release/kernel8
 OBJCOPY        = cargo objcopy --
 OBJCOPY_PARAMS = --strip-all -O binary
 
-CONTAINER_UTILS   = andrerichter/raspi3-utils
-CONTAINER_OPENOCD = andrerichter/raspi3-openocd
-CONTAINER_GDB     = andrerichter/raspi3-gdb
+CONTAINER_UTILS       = andrerichter/raspi3-utils
+CONTAINER_OPENOCD     = andrerichter/raspi3-openocd
+CONTAINER_OPENOCD_ARG = 
+# CONTAINER_OPENOCD_ARG = -f openocd/tcl/interface/ftdi/olimex-jtag-tiny.cfg -f /openocd/rpi3.cfg
+CONTAINER_GDB         = andrerichter/raspi3-gdb
 
 DOCKER_CMD        = docker run -it --rm
 DOCKER_ARG_CURDIR = -v $(shell pwd):/work -w /work
@@ -43,8 +45,10 @@ DOCKER_ARG_TTY    = --privileged -v /dev:/dev
 DOCKER_ARG_JTAG   = -v $(shell pwd)/../X1_JTAG_boot:/jtag
 DOCKER_ARG_NET    = --network host
 
-DOCKER_EXEC_QEMU     = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
-DOCKER_EXEC_RASPBOOT = raspbootcom /dev/ttyUSB0
+DOCKER_EXEC_QEMU         = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
+DOCKER_EXEC_RASPBOOT     = raspbootcom
+DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyUSB0
+# DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyACM0
 
 .PHONY: all qemu raspboot clippy clean objdump nm jtagboot openocd gdb gdb-opt0
 
@@ -79,10 +83,10 @@ nm:
 
 jtagboot:
 	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_JTAG) $(CONTAINER_UTILS) \
-	$(DOCKER_EXEC_RASPBOOT) /jtag/jtag_boot.img
+	$(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) /jtag/jtag_boot.img
 
 openocd:
-	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD)
+	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD) $(CONTAINER_OPENOCD_ARG)
 
 define gen_gdb
 	$(XRUSTC_CMD) -- $1

--- a/0B_hw_debug_JTAG/README.md
+++ b/0B_hw_debug_JTAG/README.md
@@ -34,68 +34,20 @@ Unfortunately, the RPi does not, so we have to connect it via jumper wires.
 
 ### Wiring
 
-<table>
-    <thead>
-        <tr>
-            <th>GPIO #</th>
-			<th>Name</th>
-			<th>JTAG #</th>
-			<th>Note</th>
-			<th width="60%">Diagram</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td></td>
-            <td>VTREF</td>
-            <td>1</td>
-            <td>to 3.3V</td>
-            <td rowspan="8"><img src="../doc/wiring_jtag.png"></td>
-        </tr>
-        <tr>
-            <td></td>
-            <td>GND</td>
-            <td>4</td>
-            <td>to GND</td>
-        </tr>
-        <tr>
-            <td>22</td>
-            <td>TRST</td>
-            <td>3</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>26</td>
-            <td>TDI</td>
-            <td>5</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>27</td>
-            <td>TMS</td>
-            <td>7</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>25</td>
-            <td>TCK</td>
-            <td>9</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>23</td>
-            <td>RTCK</td>
-            <td>11</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>24</td>
-            <td>TDO</td>
-            <td>13</td>
-            <td></td>
-        </tr>
-    </tbody>
-</table>
+
+```
+ GPIO Name  JTAG Note
+----------------------
+ 1    VTREF 1    3.3v
+ 6    GND   4    Gnd
+ 22   TRST  3
+ 26   TDI   5
+ 27   TMS   7
+ 25   TCK   9
+ 23   RTCK  11
+ 24   TDO   13
+```
+<p align="center"><img src="../doc/wiring_jtag.png" width="100%"></p>
 
 <p align="center"><img src="../doc/image_jtag_connected.jpg" width="50%"></p>
 


### PR DESCRIPTION
HTML table renders illegibly in okular 1.4.3: 

![image](https://user-images.githubusercontent.com/8713278/66257137-dd74c100-e75a-11e9-90fa-62c086d00bef.png)

This pull request  replaces the HTML table with markdown code block:

![image](https://user-images.githubusercontent.com/8713278/66257185-57a54580-e75b-11e9-9441-dcde658beddc.png)


I don't know if it's worth trying to target rendering deficiencies in various markdown readers. Might be worth asking how many people work through the tutorials online.

Another option might be to leave the HTML table and put a text version in an HTML comment block so it's not rendered but still readable in a text editor.