### PR TITLE
add openocd argument and raspboot device vars

### DIFF
--- a/07_abstraction/Makefile
+++ b/07_abstraction/Makefile
@@ -39,8 +39,10 @@ DOCKER_CMD        = docker run -it --rm
 DOCKER_ARG_CURDIR = -v $(shell pwd):/work -w /work
 DOCKER_ARG_TTY    = --privileged -v /dev:/dev
 
-DOCKER_EXEC_QEMU     = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
-DOCKER_EXEC_RASPBOOT = raspbootcom /dev/ttyUSB0
+DOCKER_EXEC_QEMU         = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
+DOCKER_EXEC_RASPBOOT     = raspbootcom
+DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyUSB0
+# DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyACM0
 
 .PHONY: all qemu raspboot clippy clean objdump nm
 
@@ -59,7 +61,8 @@ qemu: all
 
 raspboot: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(DOCKER_ARG_TTY) \
-	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) kernel8.img
+	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) \
+	kernel8.img
 
 clippy:
 	cargo xclippy --target=$(TARGET)

--- a/08_random/Makefile
+++ b/08_random/Makefile
@@ -40,7 +40,9 @@ DOCKER_ARG_CURDIR = -v $(shell pwd):/work -w /work
 DOCKER_ARG_TTY    = --privileged -v /dev:/dev
 
 DOCKER_EXEC_QEMU     = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
-DOCKER_EXEC_RASPBOOT = raspbootcom /dev/ttyUSB0
+DOCKER_EXEC_RASPBOOT     = raspbootcom
+DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyUSB0
+# DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyACM0
 
 .PHONY: all qemu raspboot clippy clean objdump nm
 
@@ -59,7 +61,8 @@ qemu: all
 
 raspboot: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(DOCKER_ARG_TTY) \
-	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) kernel8.img
+	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) \
+	kernel8.img
 
 clippy:
 	cargo xclippy --target=$(TARGET)

--- a/09_delays/Makefile
+++ b/09_delays/Makefile
@@ -39,8 +39,10 @@ DOCKER_CMD        = docker run -it --rm
 DOCKER_ARG_CURDIR = -v $(shell pwd):/work -w /work
 DOCKER_ARG_TTY    = --privileged -v /dev:/dev
 
-DOCKER_EXEC_QEMU     = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
-DOCKER_EXEC_RASPBOOT = raspbootcom /dev/ttyUSB0
+DOCKER_EXEC_QEMU         = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
+DOCKER_EXEC_RASPBOOT     = raspbootcom
+DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyUSB0
+# DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyACM0
 
 .PHONY: all qemu raspboot clippy clean objdump nm
 
@@ -59,7 +61,8 @@ qemu: all
 
 raspboot: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(DOCKER_ARG_TTY) \
-	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) kernel8.img
+	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) \
+	kernel8.img
 
 clippy:
 	cargo xclippy --target=$(TARGET)

--- a/0A_power/Makefile
+++ b/0A_power/Makefile
@@ -39,8 +39,10 @@ DOCKER_CMD        = docker run -it --rm
 DOCKER_ARG_CURDIR = -v $(shell pwd):/work -w /work
 DOCKER_ARG_TTY    = --privileged -v /dev:/dev
 
-DOCKER_EXEC_QEMU     = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
-DOCKER_EXEC_RASPBOOT = raspbootcom /dev/ttyUSB0
+DOCKER_EXEC_QEMU         = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
+DOCKER_EXEC_RASPBOOT     = raspbootcom
+DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyUSB0
+# DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyACM0
 
 .PHONY: all qemu raspboot clippy clean objdump nm
 
@@ -59,7 +61,7 @@ qemu: all
 
 raspboot: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(DOCKER_ARG_TTY) \
-	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) kernel8.img
+	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) kernel8.img
 
 clippy:
 	cargo xclippy --target=$(TARGET)

--- a/0C_exception_levels/Makefile
+++ b/0C_exception_levels/Makefile
@@ -35,6 +35,8 @@ OBJCOPY_PARAMS = --strip-all -O binary
 
 CONTAINER_UTILS   = andrerichter/raspi3-utils
 CONTAINER_OPENOCD = andrerichter/raspi3-openocd
+# CONTAINER_OPENOCD_ARG = -f openocd/tcl/interface/ftdi/olimex-jtag-tiny.cfg -f /openocd/rpi3.cfg
+
 CONTAINER_GDB     = andrerichter/raspi3-gdb
 
 DOCKER_CMD        = docker run -it --rm
@@ -43,8 +45,11 @@ DOCKER_ARG_TTY    = --privileged -v /dev:/dev
 DOCKER_ARG_JTAG   = -v $(shell pwd)/../X1_JTAG_boot:/jtag
 DOCKER_ARG_NET    = --network host
 
-DOCKER_EXEC_QEMU     = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
-DOCKER_EXEC_RASPBOOT = raspbootcom /dev/ttyUSB0
+DOCKER_EXEC_QEMU         = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
+DOCKER_EXEC_RASPBOOT     = raspbootcom
+DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyUSB0
+# DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyACM0
+
 
 .PHONY: all qemu raspboot clippy clean objdump nm jtagboot openocd gdb gdb-opt0
 
@@ -63,7 +68,8 @@ qemu: all
 
 raspboot: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(DOCKER_ARG_TTY) \
-	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) kernel8.img
+	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) \
+	kernel8.img
 
 clippy:
 	cargo xclippy --target=$(TARGET)
@@ -79,10 +85,11 @@ nm:
 
 jtagboot:
 	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_JTAG) $(CONTAINER_UTILS) \
-	$(DOCKER_EXEC_RASPBOOT) /jtag/jtag_boot.img
+	$(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) /jtag/jtag_boot.img
 
 openocd:
-	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD)
+	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD) \
+	$(CONTAINER_OPENOCD_ARG)
 
 define gen_gdb
 	$(XRUSTC_CMD) -- $1

--- a/0D_virtual_memory/Makefile
+++ b/0D_virtual_memory/Makefile
@@ -33,9 +33,10 @@ CARGO_OUTPUT = target/$(TARGET)/release/kernel8
 OBJCOPY        = cargo objcopy --
 OBJCOPY_PARAMS = --strip-all -O binary
 
-CONTAINER_UTILS   = andrerichter/raspi3-utils
-CONTAINER_OPENOCD = andrerichter/raspi3-openocd
-CONTAINER_GDB     = andrerichter/raspi3-gdb
+CONTAINER_UTILS       = andrerichter/raspi3-utils
+CONTAINER_OPENOCD     = andrerichter/raspi3-openocd
+# CONTAINER_OPENOCD_ARG = -f openocd/tcl/interface/ftdi/olimex-jtag-tiny.cfg -f /openocd/rpi3.cfg
+CONTAINER_GDB         = andrerichter/raspi3-gdb
 
 DOCKER_CMD        = docker run -it --rm
 DOCKER_ARG_CURDIR = -v $(shell pwd):/work -w /work
@@ -43,8 +44,11 @@ DOCKER_ARG_TTY    = --privileged -v /dev:/dev
 DOCKER_ARG_JTAG   = -v $(shell pwd)/../X1_JTAG_boot:/jtag
 DOCKER_ARG_NET    = --network host
 
-DOCKER_EXEC_QEMU     = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
-DOCKER_EXEC_RASPBOOT = raspbootcom /dev/ttyUSB0
+DOCKER_EXEC_QEMU         = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
+DOCKER_EXEC_RASPBOOT     = raspbootcom
+DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyUSB0
+# DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyACM0
+
 
 .PHONY: all qemu raspboot clippy clean objdump nm jtagboot openocd gdb gdb-opt0
 
@@ -63,7 +67,8 @@ qemu: all
 
 raspboot: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(DOCKER_ARG_TTY) \
-	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) kernel8.img
+	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) \
+	$(DOCKER_EXEC_RASPBOOT_DEV) kernel8.img
 
 clippy:
 	cargo xclippy --target=$(TARGET)
@@ -79,10 +84,11 @@ nm:
 
 jtagboot:
 	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_JTAG) $(CONTAINER_UTILS) \
-	$(DOCKER_EXEC_RASPBOOT) /jtag/jtag_boot.img
+	$(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) /jtag/jtag_boot.img
 
 openocd:
-	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD)
+	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD) \
+	$(CONTAINER_OPENOCD_ARG)
 
 define gen_gdb
 	$(XRUSTC_CMD) -- $1

--- a/0E_cache_performance/Makefile
+++ b/0E_cache_performance/Makefile
@@ -33,9 +33,10 @@ CARGO_OUTPUT = target/$(TARGET)/release/kernel8
 OBJCOPY        = cargo objcopy --
 OBJCOPY_PARAMS = --strip-all -O binary
 
-CONTAINER_UTILS   = andrerichter/raspi3-utils
-CONTAINER_OPENOCD = andrerichter/raspi3-openocd
-CONTAINER_GDB     = andrerichter/raspi3-gdb
+CONTAINER_UTILS       = andrerichter/raspi3-utils
+CONTAINER_OPENOCD     = andrerichter/raspi3-openocd
+# CONTAINER_OPENOCD_ARG = -f openocd/tcl/interface/ftdi/olimex-jtag-tiny.cfg -f /openocd/rpi3.cfg
+CONTAINER_GDB         = andrerichter/raspi3-gdb
 
 DOCKER_CMD        = docker run -it --rm
 DOCKER_ARG_CURDIR = -v $(shell pwd):/work -w /work
@@ -43,8 +44,10 @@ DOCKER_ARG_TTY    = --privileged -v /dev:/dev
 DOCKER_ARG_JTAG   = -v $(shell pwd)/../X1_JTAG_boot:/jtag
 DOCKER_ARG_NET    = --network host
 
-DOCKER_EXEC_QEMU     = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
-DOCKER_EXEC_RASPBOOT = raspbootcom /dev/ttyUSB0
+DOCKER_EXEC_QEMU         = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
+DOCKER_EXEC_RASPBOOT     = raspbootcom
+DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyUSB0
+# DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyACM0
 
 .PHONY: all qemu raspboot clippy clean objdump nm jtagboot openocd gdb gdb-opt0
 
@@ -63,7 +66,8 @@ qemu: all
 
 raspboot: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(DOCKER_ARG_TTY) \
-	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) kernel8.img
+	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) \
+	$(DOCKER_EXEC_RASPBOOT_DEV) kernel8.img
 
 clippy:
 	cargo xclippy --target=$(TARGET)
@@ -79,10 +83,11 @@ nm:
 
 jtagboot:
 	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_JTAG) $(CONTAINER_UTILS) \
-	$(DOCKER_EXEC_RASPBOOT) /jtag/jtag_boot.img
+	$(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) /jtag/jtag_boot.img
 
 openocd:
-	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD)
+	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD) \
+	$(CONTAINER_OPENOCD_ARG)
 
 define gen_gdb
 	$(XRUSTC_CMD) -- $1

--- a/0F_globals_synchronization_println/Makefile
+++ b/0F_globals_synchronization_println/Makefile
@@ -33,9 +33,10 @@ CARGO_OUTPUT = target/$(TARGET)/release/kernel8
 OBJCOPY        = cargo objcopy --
 OBJCOPY_PARAMS = --strip-all -O binary
 
-CONTAINER_UTILS   = andrerichter/raspi3-utils
-CONTAINER_OPENOCD = andrerichter/raspi3-openocd
-CONTAINER_GDB     = andrerichter/raspi3-gdb
+CONTAINER_UTILS       = andrerichter/raspi3-utils
+CONTAINER_OPENOCD     = andrerichter/raspi3-openocd
+# CONTAINER_OPENOCD_ARG = -f openocd/tcl/interface/ftdi/olimex-jtag-tiny.cfg -f /openocd/rpi3.cfg
+CONTAINER_GDB         = andrerichter/raspi3-gdb
 
 DOCKER_CMD        = docker run -it --rm
 DOCKER_ARG_CURDIR = -v $(shell pwd):/work -w /work
@@ -43,8 +44,10 @@ DOCKER_ARG_TTY    = --privileged -v /dev:/dev
 DOCKER_ARG_JTAG   = -v $(shell pwd)/../X1_JTAG_boot:/jtag
 DOCKER_ARG_NET    = --network host
 
-DOCKER_EXEC_QEMU     = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
-DOCKER_EXEC_RASPBOOT = raspbootcom /dev/ttyUSB0
+DOCKER_EXEC_QEMU         = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
+DOCKER_EXEC_RASPBOOT     = raspbootcom
+DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyUSB0
+# DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyACM0
 
 .PHONY: all qemu raspboot clippy clean objdump nm jtagboot openocd gdb gdb-opt0
 
@@ -63,7 +66,8 @@ qemu: all
 
 raspboot: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(DOCKER_ARG_TTY) \
-	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) kernel8.img
+	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) \
+	kernel8.img
 
 clippy:
 	cargo xclippy --target=$(TARGET)
@@ -79,10 +83,11 @@ nm:
 
 jtagboot:
 	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_JTAG) $(CONTAINER_UTILS) \
-	$(DOCKER_EXEC_RASPBOOT) /jtag/jtag_boot.img
+	$(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) /jtag/jtag_boot.img
 
 openocd:
-	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD)
+	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD) \
+	$(CONTAINER_OPENOCD_ARG)
 
 define gen_gdb
 	$(XRUSTC_CMD) -- $1

--- a/10_DMA_memory/Makefile
+++ b/10_DMA_memory/Makefile
@@ -33,9 +33,10 @@ CARGO_OUTPUT = target/$(TARGET)/release/kernel8
 OBJCOPY        = cargo objcopy --
 OBJCOPY_PARAMS = --strip-all -O binary
 
-CONTAINER_UTILS   = andrerichter/raspi3-utils
-CONTAINER_OPENOCD = andrerichter/raspi3-openocd
-CONTAINER_GDB     = andrerichter/raspi3-gdb
+CONTAINER_UTILS       = andrerichter/raspi3-utils
+CONTAINER_OPENOCD     = andrerichter/raspi3-openocd
+# CONTAINER_OPENOCD_ARG = -f openocd/tcl/interface/ftdi/olimex-jtag-tiny.cfg -f /openocd/rpi3.cfg
+CONTAINER_GDB         = andrerichter/raspi3-gdb
 
 DOCKER_CMD        = docker run -it --rm
 DOCKER_ARG_CURDIR = -v $(shell pwd):/work -w /work
@@ -44,8 +45,10 @@ DOCKER_ARG_JTAG   = -v $(shell pwd)/../X1_JTAG_boot:/jtag
 DOCKER_ARG_NET    = --network host
 DOCKER_ARG_EMU    = -v $(shell pwd)/../emulation:/emulation
 
-DOCKER_EXEC_QEMU     = bash /emulation/qemu_multi_uart.sh
-DOCKER_EXEC_RASPBOOT = raspbootcom /dev/ttyUSB0
+DOCKER_EXEC_QEMU         = bash /emulation/qemu_multi_uart.sh
+DOCKER_EXEC_RASPBOOT     = raspbootcom
+DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyUSB0
+# DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyACM0
 
 .PHONY: all qemu raspboot clippy clean objdump nm jtagboot openocd gdb gdb-opt0
 
@@ -60,11 +63,12 @@ kernel8.img: $(CARGO_OUTPUT)
 
 qemu: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(DOCKER_ARG_EMU) \
-        $(CONTAINER_UTILS) $(DOCKER_EXEC_QEMU)
+	$(CONTAINER_UTILS) $(DOCKER_EXEC_QEMU)
 
 raspboot: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(DOCKER_ARG_TTY) \
-	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) kernel8.img
+	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) \
+	kernel8.img
 
 clippy:
 	cargo xclippy --target=$(TARGET)
@@ -80,10 +84,11 @@ nm:
 
 jtagboot:
 	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_JTAG) $(CONTAINER_UTILS) \
-	$(DOCKER_EXEC_RASPBOOT) /jtag/jtag_boot.img
+	$(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) /jtag/jtag_boot.img
 
 openocd:
-	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD)
+	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD) \
+	$(CONTAINER_OPENOCD_ARG)
 
 define gen_gdb
 	$(XRUSTC_CMD) -- $1

--- a/11_exceptions_groundwork/Makefile
+++ b/11_exceptions_groundwork/Makefile
@@ -35,6 +35,7 @@ OBJCOPY_PARAMS = --strip-all -O binary
 
 CONTAINER_UTILS   = andrerichter/raspi3-utils
 CONTAINER_OPENOCD = andrerichter/raspi3-openocd
+# CONTAINER_OPENOCD_ARG = -f openocd/tcl/interface/ftdi/olimex-jtag-tiny.cfg -f /openocd/rpi3.cfg
 CONTAINER_GDB     = andrerichter/raspi3-gdb
 
 DOCKER_CMD        = docker run -it --rm
@@ -44,8 +45,10 @@ DOCKER_ARG_JTAG   = -v $(shell pwd)/../X1_JTAG_boot:/jtag
 DOCKER_ARG_NET    = --network host
 DOCKER_ARG_EMU    = -v $(shell pwd)/../emulation:/emulation
 
-DOCKER_EXEC_QEMU     = bash /emulation/qemu_multi_uart.sh
-DOCKER_EXEC_RASPBOOT = raspbootcom /dev/ttyUSB0
+DOCKER_EXEC_QEMU         = bash /emulation/qemu_multi_uart.sh
+DOCKER_EXEC_RASPBOOT     = raspbootcom
+DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyUSB0
+# DOCKER_EXEC_RASPBOOT_DEV = /dev/ttyACM0
 
 .PHONY: all qemu raspboot clippy clean objdump nm jtagboot openocd gdb gdb-opt0
 
@@ -60,11 +63,12 @@ kernel8.img: $(CARGO_OUTPUT)
 
 qemu: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(DOCKER_ARG_EMU) \
-        $(CONTAINER_UTILS) $(DOCKER_EXEC_QEMU)
+	$(CONTAINER_UTILS) $(DOCKER_EXEC_QEMU)
 
 raspboot: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(DOCKER_ARG_TTY) \
-	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) kernel8.img
+	$(CONTAINER_UTILS) $(DOCKER_EXEC_RASPBOOT) \
+	$(DOCKER_EXEC_RASPBOOT_DEV) kernel8.img
 
 clippy:
 	cargo xclippy --target=$(TARGET)
@@ -80,10 +84,11 @@ nm:
 
 jtagboot:
 	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_JTAG) $(CONTAINER_UTILS) \
-	$(DOCKER_EXEC_RASPBOOT) /jtag/jtag_boot.img
+	$(DOCKER_EXEC_RASPBOOT) $(DOCKER_EXEC_RASPBOOT_DEV) /jtag/jtag_boot.img
 
 openocd:
-	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD)
+	$(DOCKER_CMD) $(DOCKER_ARG_TTY) $(DOCKER_ARG_NET) $(CONTAINER_OPENOCD) \
+	$(CONTAINER_OPENOCD_ARG)
 
 define gen_gdb
 	$(XRUSTC_CMD) -- $1

--- a/X1_JTAG_boot/Makefile
+++ b/X1_JTAG_boot/Makefile
@@ -33,7 +33,10 @@ UTILS_CONTAINER = andrerichter/raspi3-utils
 DOCKER_CMD = docker run -it --rm -v $(shell pwd):/work -w /work
 DOCKER_TTY = --privileged -v /dev:/dev
 QEMU_CMD = qemu-system-aarch64 -M raspi3 -kernel jtag_boot.img
-RASPBOOT_CMD = raspbootcom /dev/ttyUSB0 jtag_boot.img
+RASPBOOT_CMD = raspbootcom
+RASPBOOT_DEV = /dev/ttyUSB0
+# RASPBOOT_DEV = /dev/ttyACM0
+
 
 .PHONY: all qemu raspboot clippy clean objdump nm
 
@@ -50,7 +53,8 @@ qemu: all
 	$(DOCKER_CMD) $(UTILS_CONTAINER) $(QEMU_CMD) -serial null -serial stdio
 
 raspboot: all
-	$(DOCKER_CMD) $(DOCKER_TTY) $(UTILS_CONTAINER) $(RASPBOOT_CMD)
+	$(DOCKER_CMD) $(DOCKER_TTY) $(UTILS_CONTAINER) $(RASPBOOT_CMD) \
+	$(RASPBOOT_DEV) jtag_boot.img
 
 clippy:
 	cargo xclippy --target=$(TARGET)


### PR DESCRIPTION
Where applicable the altered makefile targets "raspboot", "jtagboot", and "openocd" were built and tested with hardware.